### PR TITLE
Adicionar configuração do Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/Site" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
O [Dependabot](https://docs.github.com/pt/code-security/getting-started/dependabot-quickstart-guide) verifica automaticamente atualizações de dependências do nosso projeto (nessa configuração, tanto do site quanto de qualquer GitHub Action que adicionarmos), criando pull requests com tais mudanças aplicadas.