### PR TITLE
Resolver alerta de segurança 1

### DIFF
--- a/.github/workflows/verificar-build-site.yml
+++ b/.github/workflows/verificar-build-site.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Usar pNpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        package_json_file: Site/package.json
     
     - name: Usar Node.js
       uses: actions/setup-node@v4

--- a/Site/package.json
+++ b/Site/package.json
@@ -2,6 +2,7 @@
 	"name": "teste-svelte",
 	"version": "0.0.1",
 	"type": "module",
+	"packageManager": "pnpm@9.12.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -29,5 +30,10 @@
 		"tailwindcss": "^3.4.16",
 		"typescript": "^5.7.2",
 		"vite": "^5.0.3"
+	},
+	"pnpm": {
+		"overrides": {
+			"cookie@<0.7.0": ">=0.7.0"
+		}
 	}
 }

--- a/Site/pnpm-lock.yaml
+++ b/Site/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  cookie@<0.7.0: '>=0.7.0'
+
 importers:
 
   .:
@@ -514,9 +517,9 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
-    engines: {node: '>= 0.6'}
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1368,7 +1371,7 @@ snapshots:
     dependencies:
       '@sveltejs/vite-plugin-svelte': 4.0.2(svelte@5.9.0)(vite@5.4.10)
       '@types/cookie': 0.6.0
-      cookie: 0.6.0
+      cookie: 1.0.2
       devalue: 5.1.1
       esm-env: 1.2.1
       import-meta-resolve: 4.1.0
@@ -1521,7 +1524,7 @@ snapshots:
 
   commander@4.1.1: {}
 
-  cookie@0.6.0: {}
+  cookie@1.0.2: {}
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
Relacionado:

https://github.com/jhenriquelc/VelocityVanguards-2024.2/security/dependabot/1

Inclui:

* Sugerir que seja utilizado pNpm no package.json
* Substituir versão da dependência transitória vulnerável `cookie@0.6.0` trazida por `@sveltejs/kit`
* Usar versão do pNpm listada no package.json para a Action de verificação de build