### PR TITLE
Atualizar pNpm para 9.15.1

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -2,7 +2,7 @@
 	"name": "teste-svelte",
 	"version": "0.0.1",
 	"type": "module",
-	"packageManager": "pnpm@9.12.2",
+	"packageManager": "pnpm@9.15.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
Uma nova versão do pNpm foi lançada.
Este PR muda qual versão do gerenciador de pacotes é utilizada no CI, e emite erros caso alguém tente utilizar uma versão antiga no processo de desenvolvimento.